### PR TITLE
Fix footer duplication

### DIFF
--- a/WebSite 1/script.js
+++ b/WebSite 1/script.js
@@ -145,9 +145,10 @@ window.addEventListener("DOMContentLoaded", () => {
             card.style.transition = "opacity 0.6s ease-out";
             card.style.opacity = 1;
         }, 100 * i);
-		
-		addYearBadges();
-		addFloatingIcons();
-		addGlobalFooter();
     });
+
+    // These functions should only run once after the cards are processed
+    addYearBadges();
+    addFloatingIcons();
+    addGlobalFooter();
 });


### PR DESCRIPTION
## Summary
- stop adding multiple footers by moving `addGlobalFooter()` and related calls out of the animation loop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847e6573fc4832587990f95bfc6b96d