### PR TITLE
Add admin page for new exhibits

### DIFF
--- a/WebSite 1/add_exhibit.html
+++ b/WebSite 1/add_exhibit.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8"/>
+<title>Neues Exponat</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container my-5">
+<button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<a class="btn btn-secondary mb-3" href="index.html">← Zurück</a>
+<h1 class="mb-3">Neues Exponat anlegen</h1>
+<div class="mb-3">
+<label for="titleInput" class="form-label">Titel</label>
+<input type="text" id="titleInput" class="form-control"/>
+</div>
+<div class="mb-3">
+<label for="descInput" class="form-label">Kurzbeschreibung</label>
+<textarea id="descInput" class="form-control" rows="3"></textarea>
+</div>
+<div class="mb-3">
+<label for="yearInput" class="form-label">Jahr</label>
+<input type="text" id="yearInput" class="form-control"/>
+</div>
+<div class="mb-3">
+<label for="manufacturerInput" class="form-label">Hersteller</label>
+<input type="text" id="manufacturerInput" class="form-control"/>
+</div>
+<button class="btn btn-primary" onclick="saveNewExhibit()">Speichern</button>
+</div>
+<div id="adminModal">
+  <div id="adminModalContent">
+    <h3>Admin Login</h3>
+    <input type="password" id="adminPassword" class="form-control mb-3" placeholder="Passwort">
+    <div class="btn-group">
+        <button class="btn btn-primary" onclick="confirmAdminLogin()">Einloggen</button>
+        <button class="btn btn-secondary" onclick="hideAdminLogin()">Abbrechen</button>
+    </div>
+  </div>
+</div>
+<script src="script.js"></script>
+<script>
+function showAdminLogin() {
+    document.getElementById("adminModal").style.display = "block";
+    document.getElementById("adminPassword").focus();
+}
+function hideAdminLogin() {
+    document.getElementById("adminModal").style.display = "none";
+}
+function confirmAdminLogin() {
+    const input = document.getElementById("adminPassword").value;
+    if (input === "admin123") {
+        sessionStorage.setItem("admin", "true");
+        hideAdminLogin();
+        applyAdminMode();
+    } else {
+        alert("Falsches Passwort.");
+    }
+}
+function logoutAdmin() {
+    sessionStorage.removeItem("admin");
+    applyAdminMode();
+}
+function applyAdminMode() {
+    const addBtn = document.getElementById('addCardBtn');
+    if (addBtn) {
+        addBtn.style.display = sessionStorage.getItem('admin') === 'true' ? 'inline-block' : 'none';
+    }
+}
+window.addEventListener("DOMContentLoaded", () => {
+    if (performance.navigation?.type === 1 || performance.getEntriesByType("navigation")[0]?.type === "reload") {
+        sessionStorage.removeItem("admin");
+    }
+    if (sessionStorage.getItem("admin") !== "true") {
+        showAdminLogin();
+    }
+    applyAdminMode();
+});
+function saveNewExhibit() {
+    const data = {
+        title: document.getElementById('titleInput').value,
+        description: document.getElementById('descInput').value,
+        year: document.getElementById('yearInput').value,
+        manufacturer: document.getElementById('manufacturerInput').value
+    };
+    console.log('Neues Exponat:', data);
+    alert('Speichern-Logik muss serverseitig implementiert werden.');
+}
+</script>
+</body>
+</html>

--- a/WebSite 1/index.html
+++ b/WebSite 1/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <div class="container my-5">
-<div class="d-flex justify-content-between align-items-center mb-3"><h1 class="mb-0">Classic Computing Vitrine</h1><button class="btn btn-dark ms-2" onclick="toggleTheme()">🌙 Dark Mode</button></div>
+<div class="d-flex justify-content-between align-items-center mb-3"><h1 class="mb-0">Classic Computing Vitrine</h1><div><button id="addCardBtn" class="btn btn-success me-2" onclick="location.href='add_exhibit.html'" style="display:none;">➕</button><button class="btn btn-dark ms-2" onclick="toggleTheme()">🌙 Dark Mode</button></div></div>
 <input class="form-control mb-4" id="searchInput" onkeyup="filterEntries()" placeholder="Suche nach Hersteller oder Jahr..." type="text"/>
 <div class="row" id="entries">
 <div class="col-md-4 entry" data-tags="MITS 1975">
@@ -260,6 +260,10 @@ function applyAdminMode() {
     document.querySelectorAll(".admin-edit").forEach(el => {
         el.style.display = sessionStorage.getItem("admin") === "true" ? "inline-block" : "none";
     });
+    const addBtn = document.getElementById('addCardBtn');
+    if (addBtn) {
+        addBtn.style.display = sessionStorage.getItem('admin') === 'true' ? 'inline-block' : 'none';
+    }
 }
 
 window.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- add `add_exhibit.html` with form for new exhibits
- add "add" button to index page and toggle its visibility with admin login

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847e7bf3d608325aa41123646ae197e