### PR TITLE
Add custom exhibit creation

### DIFF
--- a/WebSite 1/add_exhibit.html
+++ b/WebSite 1/add_exhibit.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8"/>
+<title>Neues Exponat</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container my-5">
+<button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<a class="btn btn-secondary mb-3" href="index.html">← Zurück</a>
+<h1 class="mb-3">Neues Exponat anlegen</h1>
+<div class="mb-3">
+<label for="titleInput" class="form-label">Titel</label>
+<input type="text" id="titleInput" class="form-control"/>
+</div>
+<div class="mb-3">
+<label for="descInput" class="form-label">Kurzbeschreibung</label>
+<textarea id="descInput" class="form-control" rows="3"></textarea>
+</div>
+<div class="mb-3">
+<label for="yearInput" class="form-label">Jahr</label>
+<input type="text" id="yearInput" class="form-control"/>
+</div>
+<div class="mb-3">
+<label for="manufacturerInput" class="form-label">Hersteller</label>
+<input type="text" id="manufacturerInput" class="form-control"/>
+</div>
+<button class="btn btn-primary" onclick="saveNewExhibit()">Speichern</button>
+</div>
+<div id="adminModal">
+  <div id="adminModalContent">
+    <h3>Admin Login</h3>
+    <input type="password" id="adminPassword" class="form-control mb-3" placeholder="Passwort">
+    <div class="btn-group">
+        <button class="btn btn-primary" onclick="confirmAdminLogin()">Einloggen</button>
+        <button class="btn btn-secondary" onclick="hideAdminLogin()">Abbrechen</button>
+    </div>
+  </div>
+</div>
+<script src="script.js"></script>
+<script>
+function showAdminLogin() {
+    document.getElementById("adminModal").style.display = "block";
+    document.getElementById("adminPassword").focus();
+}
+function hideAdminLogin() {
+    document.getElementById("adminModal").style.display = "none";
+}
+function confirmAdminLogin() {
+    const input = document.getElementById("adminPassword").value;
+    if (input === "admin123") {
+        sessionStorage.setItem("admin", "true");
+        hideAdminLogin();
+        applyAdminMode();
+    } else {
+        alert("Falsches Passwort.");
+    }
+}
+function logoutAdmin() {
+    sessionStorage.removeItem("admin");
+    applyAdminMode();
+}
+function applyAdminMode() {
+    const addBtn = document.getElementById('addCardBtn');
+    if (addBtn) {
+        addBtn.style.display = sessionStorage.getItem('admin') === 'true' ? 'inline-block' : 'none';
+    }
+}
+window.addEventListener("DOMContentLoaded", () => {
+    if (performance.navigation?.type === 1 || performance.getEntriesByType("navigation")[0]?.type === "reload") {
+        sessionStorage.removeItem("admin");
+    }
+    if (sessionStorage.getItem("admin") !== "true") {
+        showAdminLogin();
+    }
+    applyAdminMode();
+});
+function saveNewExhibit() {
+    const exhibit = {
+        id: slugify(document.getElementById('titleInput').value),
+        title: document.getElementById('titleInput').value,
+        description: document.getElementById('descInput').value,
+        year: document.getElementById('yearInput').value,
+        manufacturer: document.getElementById('manufacturerInput').value
+    };
+    addCustomExhibit(exhibit);
+    // Nach dem Speichern zurück zur Startseite, damit die neue Karte sichtbar ist
+    window.location.href = 'index.html';
+}
+</script>
+</body>
+</html>

--- a/WebSite 1/devices/exhibit.html
+++ b/WebSite 1/devices/exhibit.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8"/>
+<title id="pageTitle">Exponat</title>
+<link href="../style.css" rel="stylesheet"/>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container my-5">
+<button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
+<h1 class="mb-3"><span id="title"></span></h1>
+<p><strong>Hersteller:</strong> <span id="manufacturer"></span></p>
+<p><strong>Jahr:</strong> <span id="year"></span></p>
+<p id="description"></p>
+</div>
+<div id="adminModal">
+  <div id="adminModalContent">
+    <h3>Admin Login</h3>
+    <input type="password" id="adminPassword" class="form-control mb-3" placeholder="Passwort">
+    <div class="btn-group">
+        <button class="btn btn-primary" onclick="confirmAdminLogin()">Einloggen</button>
+        <button class="btn btn-secondary" onclick="hideAdminLogin()">Abbrechen</button>
+    </div>
+  </div>
+</div>
+<script src="../script.js"></script>
+<script>
+function showAdminLogin() {
+    document.getElementById("adminModal").style.display = "block";
+    document.getElementById("adminPassword").focus();
+}
+function hideAdminLogin() {
+    document.getElementById("adminModal").style.display = "none";
+}
+function confirmAdminLogin() {
+    const input = document.getElementById("adminPassword").value;
+    if (input === "admin123") {
+        sessionStorage.setItem("admin", "true");
+        hideAdminLogin();
+        applyAdminMode();
+    } else {
+        alert("Falsches Passwort.");
+    }
+}
+function logoutAdmin() {
+    sessionStorage.removeItem("admin");
+    applyAdminMode();
+}
+function applyAdminMode() {
+    document.querySelectorAll(".admin-edit").forEach(el => {
+        el.style.display = sessionStorage.getItem("admin") === "true" ? "inline-block" : "none";
+    });
+}
+window.addEventListener("DOMContentLoaded", () => {
+    if (performance.navigation?.type === 1 || performance.getEntriesByType("navigation")[0]?.type === "reload") {
+        sessionStorage.removeItem("admin");
+    }
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    const exhibits = JSON.parse(localStorage.getItem('customExhibits') || '[]');
+    const ex = exhibits.find(e => e.id === id);
+    if (ex) {
+        document.getElementById('title').textContent = ex.title;
+        document.getElementById('pageTitle').textContent = ex.title;
+        document.getElementById('manufacturer').textContent = ex.manufacturer;
+        document.getElementById('year').textContent = ex.year;
+        document.getElementById('description').textContent = ex.description;
+    } else {
+        document.getElementById('title').textContent = 'Unbekanntes Exponat';
+    }
+    applyAdminMode();
+    addFloatingIcons();
+    document.addEventListener("keydown", function(e) {
+        if (e.shiftKey && e.ctrlKey) {
+            if (sessionStorage.getItem("admin") === "true") {
+                logoutAdmin();
+            } else {
+                showAdminLogin();
+            }
+        }
+    });
+    document.addEventListener("keydown", function(e) {
+        if (document.getElementById("adminModal").style.display === "block" && e.key === "Enter") {
+            confirmAdminLogin();
+        }
+    });
+});
+function editField(id) {
+    const element = document.getElementById(id);
+    const newText = prompt("Neuer Text:", element.innerText);
+    if (newText !== null) {
+        element.innerText = newText;
+    }
+}
+</script>
+<style>
+#adminModal {
+    position: fixed;
+    z-index: 9999;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    background-color: rgba(0,0,0,0.6);
+    display: none;
+}
+#adminModalContent {
+    background: white;
+    padding: 30px;
+    max-width: 400px;
+    margin: 150px auto;
+    border-radius: 10px;
+    text-align: center;
+    font-family: Arial, sans-serif;
+    color: #000;
+}
+body.dark-mode #adminModalContent {
+    background: #222;
+    color: #fff;
+}
+body.dark-mode #adminModalContent button {
+    color: #fff;
+}
+</style>
+</body>
+</html>

--- a/WebSite 1/index.html
+++ b/WebSite 1/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <div class="container my-5">
-<div class="d-flex justify-content-between align-items-center mb-3"><h1 class="mb-0">Classic Computing Vitrine</h1><button class="btn btn-dark ms-2" onclick="toggleTheme()">🌙 Dark Mode</button></div>
+<div class="d-flex justify-content-between align-items-center mb-3"><h1 class="mb-0">Classic Computing Vitrine</h1><div><button id="addCardBtn" class="btn btn-success me-2" onclick="location.href='add_exhibit.html'" style="display:none;">➕</button><button class="btn btn-dark ms-2" onclick="toggleTheme()">🌙 Dark Mode</button></div></div>
 <input class="form-control mb-4" id="searchInput" onkeyup="filterEntries()" placeholder="Suche nach Hersteller oder Jahr..." type="text"/>
 <div class="row" id="entries">
 <div class="col-md-4 entry" data-tags="MITS 1975">
@@ -260,6 +260,10 @@ function applyAdminMode() {
     document.querySelectorAll(".admin-edit").forEach(el => {
         el.style.display = sessionStorage.getItem("admin") === "true" ? "inline-block" : "none";
     });
+    const addBtn = document.getElementById('addCardBtn');
+    if (addBtn) {
+        addBtn.style.display = sessionStorage.getItem('admin') === 'true' ? 'inline-block' : 'none';
+    }
 }
 
 window.addEventListener("DOMContentLoaded", () => {
@@ -267,6 +271,8 @@ window.addEventListener("DOMContentLoaded", () => {
         sessionStorage.removeItem("admin");
     }
     applyAdminMode();
+    renderCustomExhibits();
+    addYearBadges();
 
     document.addEventListener("keydown", function(e) {
         if (e.shiftKey && e.ctrlKey) {

--- a/WebSite 1/script.js
+++ b/WebSite 1/script.js
@@ -151,3 +151,50 @@ window.addEventListener("DOMContentLoaded", () => {
 		addGlobalFooter();
     });
 });
+
+// ----- Custom Exhibits -----
+function slugify(text) {
+    return (
+        text.toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '') + '-' + Date.now()
+    );
+}
+
+function loadCustomExhibits() {
+    return JSON.parse(localStorage.getItem('customExhibits') || '[]');
+}
+
+function saveCustomExhibits(data) {
+    localStorage.setItem('customExhibits', JSON.stringify(data));
+}
+
+function addCustomExhibit(exhibit) {
+    const exhibits = loadCustomExhibits();
+    exhibits.push(exhibit);
+    saveCustomExhibits(exhibits);
+}
+
+function renderCustomExhibits() {
+    const container = document.getElementById('entries');
+    if (!container) return;
+    const exhibits = loadCustomExhibits();
+    exhibits.forEach((ex, i) => {
+        const col = document.createElement('div');
+        col.className = 'col-md-4 entry';
+        col.setAttribute('data-tags', `${ex.manufacturer} ${ex.year}`);
+        col.innerHTML = `
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">
+                        <a href="devices/exhibit.html?id=${ex.id}">
+                            <span id="title_custom_${i}">${ex.title} (${ex.year})</span>
+                        </a>
+                        <button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('title_custom_${i}')" style="display:none;">✏️</button>
+                    </h5>
+                    <p class="card-text"><span id="text_custom_${i}">${ex.description}</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('text_custom_${i}')" style="display:none;">✏️</button></p>
+                </div>
+            </div>`;
+        container.appendChild(col);
+    });
+}


### PR DESCRIPTION
## Summary
- show a plus button in admin mode to add exhibits
- load custom exhibits from `localStorage` on the start page
- add an exhibit creation form and return to index on save

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847e7bf3d608325aa41123646ae197e