### PR TITLE
Add dynamic exhibits with localStorage

### DIFF
--- a/WebSite 1/add_exhibit.html
+++ b/WebSite 1/add_exhibit.html
@@ -79,13 +79,16 @@ window.addEventListener("DOMContentLoaded", () => {
 });
 function saveNewExhibit() {
     const data = {
+        id: 'new' + Date.now(),
         title: document.getElementById('titleInput').value,
         description: document.getElementById('descInput').value,
         year: document.getElementById('yearInput').value,
         manufacturer: document.getElementById('manufacturerInput').value
     };
-    console.log('Neues Exponat:', data);
-    alert('Speichern-Logik muss serverseitig implementiert werden.');
+    const exhibits = JSON.parse(localStorage.getItem('newExhibits') || '[]');
+    exhibits.push(data);
+    localStorage.setItem('newExhibits', JSON.stringify(exhibits));
+    window.location.href = 'index.html';
 }
 </script>
 </body>

--- a/WebSite 1/devices/dynamic_device.html
+++ b/WebSite 1/devices/dynamic_device.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8"/>
+    <title id="pageTitle">Neues Exponat</title>
+    <link href="../style.css" rel="stylesheet"/>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container my-5">
+    <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+    <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
+    <h1 class="mb-3" id="title">Neues Exponat</h1>
+    <p><strong>Hersteller:</strong> <span id="manufacturer"></span></p>
+    <p id="description"></p>
+</div>
+<div id="adminModal">
+  <div id="adminModalContent">
+    <h3>Admin Login</h3>
+    <input type="password" id="adminPassword" class="form-control mb-3" placeholder="Passwort">
+    <div class="btn-group">
+        <button class="btn btn-primary" onclick="confirmAdminLogin()">Einloggen</button>
+        <button class="btn btn-secondary" onclick="hideAdminLogin()">Abbrechen</button>
+    </div>
+  </div>
+</div>
+<script src="../script.js"></script>
+<script>
+function showAdminLogin() {
+    document.getElementById("adminModal").style.display = "block";
+    document.getElementById("adminPassword").focus();
+}
+function hideAdminLogin() {
+    document.getElementById("adminModal").style.display = "none";
+}
+function confirmAdminLogin() {
+    const input = document.getElementById("adminPassword").value;
+    if (input === "admin123") {
+        sessionStorage.setItem("admin", "true");
+        hideAdminLogin();
+        applyAdminMode();
+    } else {
+        alert("Falsches Passwort.");
+    }
+}
+function logoutAdmin() {
+    sessionStorage.removeItem("admin");
+    applyAdminMode();
+}
+function applyAdminMode() {
+    document.querySelectorAll(".admin-edit").forEach(el => {
+        el.style.display = sessionStorage.getItem("admin") === "true" ? "inline-block" : "none";
+    });
+}
+function loadDevice() {
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    const exhibits = JSON.parse(localStorage.getItem('newExhibits') || '[]');
+    const ex = exhibits.find(e => e.id === id);
+    if (!ex) return;
+    document.getElementById('pageTitle').innerText = ex.title;
+    document.getElementById('title').innerText = `${ex.title} (${ex.year})`;
+    document.getElementById('manufacturer').innerText = ex.manufacturer;
+    document.getElementById('description').innerText = ex.description;
+}
+window.addEventListener('DOMContentLoaded', () => {
+    if (performance.navigation?.type === 1 || performance.getEntriesByType('navigation')[0]?.type === 'reload') {
+        sessionStorage.removeItem('admin');
+    }
+    loadDevice();
+    applyAdminMode();
+    addFloatingIcons();
+});
+function editField(id) {
+    const element = document.getElementById(id);
+    const newText = prompt("Neuer Text:", element.innerText);
+    if (newText !== null) {
+        element.innerText = newText;
+    }
+}
+</script>
+</body>
+</html>

--- a/WebSite 1/script.js
+++ b/WebSite 1/script.js
@@ -130,8 +130,9 @@ window.addEventListener("DOMContentLoaded", () => {
         addGlobalFooter();
     }
 	
-	if (window.location.pathname.endsWith("index.html") || window.location.pathname === "/") {
-        sortCardsAlphabetically(); 
+        if (window.location.pathname.endsWith("index.html") || window.location.pathname === "/") {
+        sortCardsAlphabetically();
+        loadNewExhibits();
     }
 	
 	document.getElementById("searchInput")?.addEventListener("input", filterEntries);
@@ -146,8 +147,31 @@ window.addEventListener("DOMContentLoaded", () => {
             card.style.opacity = 1;
         }, 100 * i);
 		
-		addYearBadges();
-		addFloatingIcons();
-		addGlobalFooter();
+                addYearBadges();
+                addFloatingIcons();
+                addGlobalFooter();
     });
 });
+
+function addExhibitCard(ex) {
+    const container = document.getElementById('entries');
+    if (!container) return;
+    const col = document.createElement('div');
+    col.className = 'col-md-4 entry';
+    col.setAttribute('data-tags', `${ex.manufacturer} ${ex.year}`);
+
+    col.innerHTML = `
+        <div class="card">
+            <div class="card-body">
+                <h5 class="card-title"><a href="devices/dynamic_device.html?id=${ex.id}"><span id="title_${ex.id}">${ex.title} (${ex.year})</span></a><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('title_${ex.id}')" style="display:none;">✏️</button></h5>
+                <p class="card-text"><span id="text_${ex.id}">${ex.description}</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('text_${ex.id}')" style="display:none;">✏️</button></p>
+            </div>
+        </div>`;
+
+    container.appendChild(col);
+}
+
+function loadNewExhibits() {
+    const exhibits = JSON.parse(localStorage.getItem('newExhibits') || '[]');
+    exhibits.forEach(ex => addExhibitCard(ex));
+}


### PR DESCRIPTION
## Summary
- enable saving new exhibit data to `localStorage`
- render locally stored exhibits on the start page
- add generic device page that loads data from `localStorage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848069568408325a4f08ff7c48a3769