### PR TITLE
Improve responsive layout for tables

### DIFF
--- a/TABLE VIEW CSS.txt
+++ b/TABLE VIEW CSS.txt
@@ -209,3 +209,39 @@ td, th {
     margin: 10px 0;
     opacity: 0.8;
 }
+
+/* Container fuer Tabellen: nutzt immer die komplette Breite */
+#container-div, .table-container {
+    width: 100%;
+}
+
+/* Tabellen reagieren auf kleine Bildschirme durch kleinere Schrift und weniger Padding */
+@media (max-width: 1200px) {
+    .overview-table {
+        font-size: 0.9em;
+    }
+    .overview-table th,
+    .overview-table td {
+        padding: 6px;
+    }
+}
+
+@media (max-width: 900px) {
+    .overview-table {
+        font-size: 0.8em;
+    }
+    .overview-table th,
+    .overview-table td {
+        padding: 4px;
+    }
+}
+
+@media (max-width: 600px) {
+    .overview-table {
+        font-size: 0.7em;
+    }
+    .overview-table th,
+    .overview-table td {
+        padding: 2px;
+    }
+}

--- a/TABLE VIEW JS.txt
+++ b/TABLE VIEW JS.txt
@@ -102,6 +102,25 @@ function applyGlobalWidths() {
         table.style.width = globalWidths.reduce((sum, w) => sum + parseInt(w), 0) + 'px';
     });
 }
+
+/**
+ * Passt die Tabellengroesse an das umgebende Element an.
+ * Wenn die berechnete Breite groesser als der verfuegbare Platz ist,
+ * wird die Tabelle proportional skaliert, sodass keine Scrollbalken entstehen.
+ */
+function scaleTables() {
+    var tables = document.querySelectorAll('.table-container table');
+    tables.forEach(function(table) {
+        table.style.transform = 'scale(1)';
+        table.style.transformOrigin = 'top left';
+        var containerWidth = table.parentElement.clientWidth;
+        var tableWidth = table.scrollWidth;
+        if (tableWidth > containerWidth) {
+            var scale = containerWidth / tableWidth;
+            table.style.transform = 'scale(' + scale + ')';
+        }
+    });
+}
 /**
  * Synchronisiert die Scrollbewegung zwischen dem Header und der darunterliegenden Tabelle.
  */
@@ -367,6 +386,7 @@ function applyThreshold(newThreshold, categoryToSort = null, initialState = 'hid
 
     // Nach dem Neuerstellen globale Spaltenbreiten anwenden
     applyGlobalWidths();
+    scaleTables();
 
     // Beibehaltung der Scrollposition
     containerDiv.scrollTop = scrollPosition;
@@ -431,9 +451,11 @@ function initialSetup() {
     setTimeout(function() {
         // Globale Spaltenbreiten berechnen und anwenden
         applyGlobalWidths();
+        scaleTables();
 
         window.addEventListener('resize', function() {
             applyGlobalWidths();
+            scaleTables();
             updateOverviewText(parseFloat(document.getElementById('threshold-slider').value));
         });
     }, 0);


### PR DESCRIPTION
## Summary
- add JS logic to scale tables when space is limited
- trigger scaling on initial render and resize events
- introduce responsive CSS rules for smaller screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aaabf594083258d1c41eebd9e99a4