### PR TITLE
Enable language switch on device pages

### DIFF
--- a/WebSite_Language/add_exhibit.html
+++ b/WebSite_Language/add_exhibit.html
@@ -9,6 +9,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a id="backLink" class="btn btn-secondary mb-3" href="index.html">← Zurück</a>
 <h1 id="pageTitle" class="mb-3">Neues Exponat anlegen</h1>
 <div class="mb-3">

--- a/WebSite_Language/devices/altair8800.html
+++ b/WebSite_Language/devices/altair8800.html
@@ -20,6 +20,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Altair 8800 (1975)</h1>
 <img alt="Altair 8800" class="device-img" src="https://www.golem.de/2501/192414-488582-488579.jpg"/>
@@ -125,6 +129,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/atari1040st.html
+++ b/WebSite_Language/devices/atari1040st.html
@@ -10,6 +10,10 @@
 <body>
 <div class="container my-5">
     <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
     <a href="../index.html" class="btn btn-secondary mb-3">&larr; Zurück</a>
     <h1 class="mb-3">Atari 1040ST (1986)</h1>
     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Atari1040STf.jpg/640px-Atari1040STf.jpg" alt="Atari 1040ST" class="device-img mb-4" style="max-width:100%;height:auto;border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.1);">
@@ -29,6 +33,7 @@
 </div>
 
 <!-- Admin Modal und Script wird von Startseite übernommen -->
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/atarifolio.html
+++ b/WebSite_Language/devices/atarifolio.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1>Atari Portfolio (1989)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Atari (DIP Research)</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -115,6 +119,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/c16.html
+++ b/WebSite_Language/devices/c16.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Commodore 16 (1984)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Commodore International</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/c64.html
+++ b/WebSite_Language/devices/c64.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Commodore 64 (1982)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Commodore International</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/c64c.html
+++ b/WebSite_Language/devices/c64c.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Commodore 64C (1986)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Commodore International</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/cambridgez88.html
+++ b/WebSite_Language/devices/cambridgez88.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Cambridge Z88 (1987)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Cambridge Computer Ltd.</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/commodore1541.html
+++ b/WebSite_Language/devices/commodore1541.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1>Commodore 1541-II (1987)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Commodore</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -115,6 +119,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/cp1.html
+++ b/WebSite_Language/devices/cp1.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Kosmos CP1 (1983)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Kosmos Verlag</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/datasette.html
+++ b/WebSite_Language/devices/datasette.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Commodore Datasette 1530</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Commodore</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/dynamic_device.html
+++ b/WebSite_Language/devices/dynamic_device.html
@@ -9,6 +9,10 @@
 <body>
 <div class="container my-5">
     <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
     <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
     <h1 class="mb-3" id="title">Neues Exponat</h1>
     <p><strong>Hersteller:</strong> <span id="manufacturer"></span></p>
@@ -24,6 +28,7 @@
     </div>
   </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 <script>
 function showAdminLogin() {

--- a/WebSite_Language/devices/geraet24.html
+++ b/WebSite_Language/devices/geraet24.html
@@ -12,6 +12,10 @@
     <div class="d-flex justify-content-start align-items-center gap-2 mb-4">
         <a href="../index.html" class="btn btn-secondary">← Zurück</a>
         <button onclick="toggleDarkMode()" class="btn btn-dark">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
     </div>
     <h1 id="deviceTitle" contenteditable="true">Neues Gerät (Jahr)</h1>
     <img src="../img/placeholder.png" alt="Platzhalterbild" class="img-fluid my-4" style="max-height:300px;">
@@ -26,6 +30,7 @@
     <h3>Historische Bedeutung</h3>
     <p id="bedeutung" contenteditable="true">Hier einfügen...</p>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/hp45.html
+++ b/WebSite_Language/devices/hp45.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Hewlett-Packard HP-45 (1973)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> HP</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/hp95lx.html
+++ b/WebSite_Language/devices/hp95lx.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Hewlett-Packard 95LX (1991)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> HP</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/hx20.html
+++ b/WebSite_Language/devices/hx20.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Epson HX-20 (1982)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Epson</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/kenbak.html
+++ b/WebSite_Language/devices/kenbak.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Kenbak-1 (1971)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Kenbak Corporation</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/pc1251.html
+++ b/WebSite_Language/devices/pc1251.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Sharp PC-1251 (1982)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Sharp</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/pc1403.html
+++ b/WebSite_Language/devices/pc1403.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Sharp PC-1403 (1986)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Sharp</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/rd720.html
+++ b/WebSite_Language/devices/rd720.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Sharp RD-720</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Sharp</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/tamaya.html
+++ b/WebSite_Language/devices/tamaya.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Tamaya NC-2 (1976)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Tamaya &amp; Co. Ltd.</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/ti994a.html
+++ b/WebSite_Language/devices/ti994a.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Texas Instruments TI-99/4A (1981)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Texas Instruments</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/tisr56.html
+++ b/WebSite_Language/devices/tisr56.html
@@ -10,6 +10,10 @@
 <body>
 <div class="container my-5">
     <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
     <a href="../index.html" class="btn btn-secondary mb-3">&larr; Zurück</a>
     <h1 class="mb-3">TI SR-56 (1976)</h1>
     <img src="https://upload.wikimedia.org/wikipedia/commons/6/68/TI_SR-56.jpg" alt="TI SR-56" class="device-img mb-4" style="max-width:100%;height:auto;border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.1);">
@@ -119,6 +123,7 @@ function editField(id) {
   </div>
 </div>
 
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/triumphator.html
+++ b/WebSite_Language/devices/triumphator.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Triumphator CN1</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> VEB Triumphator-Werk DDR</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/zx81.html
+++ b/WebSite_Language/devices/zx81.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Sinclair ZX81 (1981)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Sinclair</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/devices/zxspectrum.html
+++ b/WebSite_Language/devices/zxspectrum.html
@@ -11,6 +11,10 @@
 <body>
 <div class="container my-5">
 <button class="btn btn-dark ms-2 mb-3" onclick="toggleTheme()">🌙 Dark Mode</button>
+<div class="btn-group ms-2 mb-3" role="group" aria-label="Language selector">
+  <button class="btn language-btn btn-sm">DE</button>
+  <button class="btn language-btn btn-sm">EN</button>
+</div>
 <a class="btn btn-secondary mb-3" href="../index.html">← Zurück</a>
 <h1 class="mb-3">Sinclair ZX Spectrum (1982)</h1>
 <p><strong>Hersteller:</strong><span id="hersteller"> Sinclair</span><button class="btn btn-sm btn-outline-primary admin-edit" onclick="editField('hersteller')" style="display:none;">✏️</button></p>
@@ -112,6 +116,7 @@ function editField(id) {
 </div>
 </div>
 </div>
+<script src="../translations.js"></script>
 <script src="../script.js"></script>
 </body>
 </html>

--- a/WebSite_Language/script.js
+++ b/WebSite_Language/script.js
@@ -212,7 +212,32 @@ function loadNewExhibits() {
 
 const pageTranslations = {
   'index.html': typeof translations_index !== 'undefined' ? translations_index : null,
-  'add_exhibit.html': typeof translations_add !== 'undefined' ? translations_add : null
+  'add_exhibit.html': typeof translations_add !== 'undefined' ? translations_add : null,
+  'altair8800.html': typeof translations_altair8800 !== 'undefined' ? translations_altair8800 : null,
+  'atari1040st.html': typeof translations_atari1040st !== 'undefined' ? translations_atari1040st : null,
+  'atarifolio.html': typeof translations_atarifolio !== 'undefined' ? translations_atarifolio : null,
+  'c16.html': typeof translations_c16 !== 'undefined' ? translations_c16 : null,
+  'c64.html': typeof translations_c64 !== 'undefined' ? translations_c64 : null,
+  'c64c.html': typeof translations_c64c !== 'undefined' ? translations_c64c : null,
+  'cambridgez88.html': typeof translations_cambridgez88 !== 'undefined' ? translations_cambridgez88 : null,
+  'commodore1541.html': typeof translations_commodore1541 !== 'undefined' ? translations_commodore1541 : null,
+  'cp1.html': typeof translations_cp1 !== 'undefined' ? translations_cp1 : null,
+  'datasette.html': typeof translations_datasette !== 'undefined' ? translations_datasette : null,
+  'dynamic_device.html': typeof translations_dynamic_device !== 'undefined' ? translations_dynamic_device : null,
+  'geraet24.html': typeof translations_geraet24 !== 'undefined' ? translations_geraet24 : null,
+  'hp45.html': typeof translations_hp45 !== 'undefined' ? translations_hp45 : null,
+  'hp95lx.html': typeof translations_hp95lx !== 'undefined' ? translations_hp95lx : null,
+  'hx20.html': typeof translations_hx20 !== 'undefined' ? translations_hx20 : null,
+  'kenbak.html': typeof translations_kenbak !== 'undefined' ? translations_kenbak : null,
+  'pc1251.html': typeof translations_pc1251 !== 'undefined' ? translations_pc1251 : null,
+  'pc1403.html': typeof translations_pc1403 !== 'undefined' ? translations_pc1403 : null,
+  'rd720.html': typeof translations_rd720 !== 'undefined' ? translations_rd720 : null,
+  'tamaya.html': typeof translations_tamaya !== 'undefined' ? translations_tamaya : null,
+  'ti994a.html': typeof translations_ti994a !== 'undefined' ? translations_ti994a : null,
+  'tisr56.html': typeof translations_tisr56 !== 'undefined' ? translations_tisr56 : null,
+  'triumphator.html': typeof translations_triumphator !== 'undefined' ? translations_triumphator : null,
+  'zx81.html': typeof translations_zx81 !== 'undefined' ? translations_zx81 : null,
+  'zxspectrum.html': typeof translations_zxspectrum !== 'undefined' ? translations_zxspectrum : null
 };
 
 function applyLanguage() {

--- a/WebSite_Language/translations.js
+++ b/WebSite_Language/translations.js
@@ -56,3 +56,238 @@ const translations_add = {
   "saveBtn": "Save",
   "backLink": "← Back"
 };
+const translations_altair8800 = {
+  "hersteller": "MITS",
+  "tech_0": "CPU: Intel 8080 @ 2 MHz",
+  "tech_1": "RAM: 256 bytes (expandable to 64 KB)",
+  "tech_2": "Control via toggle switches & LED display",
+  "tech_3": "S-100 bus for expansion",
+  "bedeutung": "The Altair 8800 is considered the starting point of the personal computer revolution. It inspired Bill Gates and Paul Allen to found Microsoft. The switch-and-LED design was iconic and shaped the early home computer era."
+};
+
+const translations_atari1040st = {
+  "hersteller": "Atari",
+  "tech_0": "CPU: Motorola 68000 @ 8 MHz",
+  "tech_1": "RAM: 1 MB",
+  "tech_2": "Resolution: up to 640x400 (monochrome)",
+  "tech_3": "Ports: MIDI, floppy drive, mouse, joysticks",
+  "bedeutung": "The Atari 1040ST was a popular home computer, especially among musicians thanks to its built-in MIDI ports. It was an affordable alternative to Apple and IBM systems."
+};
+
+const translations_atarifolio = {
+  "hersteller": "Atari",
+  "tech_0": "CPU: Intel 80C88 @ 4.91 MHz",
+  "tech_1": "RAM: 128 KB, ROM: 256 KB",
+  "tech_2": "Display: 240x64 LCD",
+  "tech_3": "PC-compatible DIP-DOS 2.11",
+  "bedeutung": "First IBM-PC compatible palmtop. Famous from Terminator 2, versatile to use – a precursor to modern handheld PCs."
+};
+
+const translations_c16 = {
+  "hersteller": "Commodore",
+  "tech_0": "Processor: MOS 7501 @ 0.89 MHz",
+  "tech_1": "RAM: 16 KB",
+  "tech_2": "Graphics: TED chip, 121 colors, 320×200",
+  "tech_3": "Sound: 2 channels, 1 noise generator",
+  "tech_4": "Storage: Datasette 1531, Floppy 1551",
+  "bedeutung": "Entry-level device of the TED series with BASIC 3.5, lag behind the C64. Popular in Europe but not a big success in the USA."
+};
+
+const translations_c64 = {
+  "hersteller": "Commodore",
+  "tech_0": "Processor: MOS 6510 @ 1 MHz",
+  "tech_1": "RAM: 64 KB",
+  "tech_2": "Graphics: VIC-II (16 colors, 320x200)",
+  "tech_3": "Sound: SID chip (3-channel)",
+  "tech_4": "Storage: Datasette, 1541 floppy, cartridge",
+  "bedeutung": "The most successful home computer of all time. Over 10,000 games and software titles. Important driver for home computing and the demo scene."
+};
+
+const translations_c64c = {
+  "hersteller": "Commodore",
+  "tech_0": "Processor: MOS 6510 or 8500 @ 0.985 MHz",
+  "tech_1": "RAM: 64 KB",
+  "tech_2": "Graphics: VIC-II, 320×200, 16 colors",
+  "tech_3": "Sound: SID 6581/8580",
+  "tech_4": "Design: Flat, modern case",
+  "bedeutung": "Technically identical to the classic C64 but with redesigned case and new mainboard. Remains fully compatible."
+};
+
+const translations_cambridgez88 = {
+  "hersteller": "Cambridge",
+  "tech_0": "Processor: Zilog Z80A @ 3.27 MHz",
+  "tech_1": "RAM: 32 KB, expandable to 3.5 MB",
+  "tech_2": "Display: 640x64 pixel monochrome LCD",
+  "tech_3": "Operating system: OZ",
+  "tech_4": "Power supply: 4x AA batteries, ~20h runtime",
+  "bedeutung": "The Cambridge Z88 was an early portable computer with word processing, BASIC and multitasking. Developed by Clive Sinclair after selling Sinclair Research."
+};
+
+const translations_commodore1541 = {
+  "hersteller": "Commodore",
+  "tech_0": "5.25\u2033 floppy drive, 170 KB per side",
+  "tech_1": "MOS 6502 CPU, 1 MHz",
+  "tech_2": "Serial IEC interface",
+  "tech_3": "External power supply",
+  "bedeutung": "Improved standard drive for the C64. More robust, cooler and durable than previous models. Cornerstone of C64 software distribution."
+};
+
+const translations_cp1 = {
+  "hersteller": "Kosmos Verlag",
+  "tech_0": "Processor: Intel 8049 @ 6 MHz",
+  "tech_1": "RAM: 256 bytes",
+  "tech_2": "Display: 6-digit 7-segment",
+  "tech_3": "Input: 30-key membrane keyboard",
+  "tech_4": "Expansion: CP2\u2013CP5 add-on modules",
+  "bedeutung": "Educational computer kit for youth. Popular in schools and among hobbyists \u2013 ideal for getting started with microcontroller technology."
+};
+
+const translations_datasette = {
+  "hersteller": "Commodore",
+  "tech_0": "Medium: Compact cassette",
+  "tech_1": "Transfer rate: approx. 60\u201370 bytes/s",
+  "tech_2": "Connection: 12-pin edge connector",
+  "tech_3": "Control: Motor + sense line via C64",
+  "tech_4": "Compatible with: VC20, C64, C128",
+  "bedeutung": "Most affordable storage solution for Commodore computers. Extremely widespread in Europe. Cult object of the home computer era."
+};
+
+const translations_dynamic_device = {
+  "pageTitle": "New Exhibit",
+  "title": "New Exhibit"
+};
+
+const translations_geraet24 = {
+  "deviceTitle": "New Device (Year)",
+  "hersteller": "Manufacturer",
+  "bedeutung": "Insert here..."
+};
+
+const translations_hp45 = {
+  "hersteller": "HP",
+  "tech_0": "Display: 10-digit LED + 2 exponent digits",
+  "tech_1": "RPN input, 4-level stack",
+  "tech_2": "9 memory registers",
+  "tech_3": "Trigonometry, statistics, conversions",
+  "tech_4": "Power: NiCd battery or power supply",
+  "bedeutung": "One of the first programmable scientific calculators with broad functionality. Known for its accuracy."
+};
+
+const translations_hp95lx = {
+  "hersteller": "HP",
+  "tech_0": "Processor: NEC V20 @ 5.37 MHz",
+  "tech_1": "RAM: 512 KB or 1 MB",
+  "tech_2": "Display: 240x128 LCD",
+  "tech_3": "Operating system: MS-DOS 3.22",
+  "tech_4": "Interfaces: RS-232, PCMCIA",
+  "bedeutung": "First palmtop with DOS, Lotus 1-2-3 and organizer functions. Extremely portable and efficient for mobile use."
+};
+
+const translations_hx20 = {
+  "hersteller": "Epson",
+  "tech_0": "Processor: 2x Hitachi 6301 CPUs @ 614 kHz",
+  "tech_1": "RAM: 16 KB (expandable)",
+  "tech_2": "Display: 120x32 LCD",
+  "tech_3": "Input device: QWERTY keyboard",
+  "tech_4": "Extras: micro-cassette recorder + printer",
+  "bedeutung": "First laptop with built-in battery, printer and storage. Compact, versatile and mobile \u2013 a true pioneer of portable computers."
+};
+
+const translations_kenbak = {
+  "hersteller": "Kenbak",
+  "tech_0": "Logic: TTL circuits (no CPU)",
+  "tech_1": "Clock: approx. 1 MHz",
+  "tech_2": "RAM: 256 bytes",
+  "tech_3": "Input: toggle switches",
+  "tech_4": "Display: LEDs in binary readout",
+  "bedeutung": "First personal computer (even before the Altair 8800). Only about 40 units built \u2013 now a rare collector's item."
+};
+
+const translations_pc1251 = {
+  "hersteller": "Sharp",
+  "tech_0": "Processor: Hitachi SC61860 @ 576 kHz",
+  "tech_1": "RAM: 4 KB",
+  "tech_2": "Display: 24-character LCD",
+  "tech_3": "BASIC programming",
+  "tech_4": "Interfaces: CE-125 for cassette/printer",
+  "bedeutung": "Compact BASIC computer for on the go. Popular with students and technicians. Distributed by RadioShack as Tandy PC-3."
+};
+
+const translations_pc1403 = {
+  "hersteller": "Sharp",
+  "tech_0": "Processor: SC61860 @ 768 kHz",
+  "tech_1": "RAM: 8\u201332 KB",
+  "tech_2": "ROM: 72 KB",
+  "tech_3": "Display: 24-character LCD",
+  "tech_4": "Audio: 4 kHz speaker",
+  "bedeutung": "Pocket computer with integrated BASIC and scientific functions. Ideal for school, university and engineering."
+};
+
+const translations_rd720 = {
+  "hersteller": "Sharp",
+  "tech_0": "Type: cassette data storage",
+  "tech_1": "Power: 4x AA or 6V adapter",
+  "tech_2": "Tape speed: 4.8 cm/s",
+  "tech_3": "Connection: for Sharp Pocket Computer",
+  "tech_4": "Extras: speaker, controls, LED",
+  "bedeutung": "External cassette recorder for BASIC programs and data. Was an inexpensive storage solution before floppy drives."
+};
+
+const translations_tamaya = {
+  "hersteller": "Tamaya & Co. Ltd.",
+  "tech_0": "Display: 8-digit LED",
+  "tech_1": "Keyboard: specialized navigation keys",
+  "tech_2": "Calculations: LOP, course, time, azimuth",
+  "tech_3": "Power: 4x AA or power supply",
+  "tech_4": "Packaging: wooden box",
+  "bedeutung": "Early navigation computer for maritime use. Reduced manual calculations and enabled precise positioning before GPS."
+};
+
+const translations_ti994a = {
+  "hersteller": "Texas Instruments",
+  "tech_0": "Processor: TMS9900 (16-bit) @ 3 MHz",
+  "tech_1": "RAM: 16 KB, ROM: 26 KB",
+  "tech_2": "Graphics: 256x192, 16 colors",
+  "tech_3": "Sound: 3-channel + noise generator",
+  "tech_4": "Ports: TV, joysticks, expansion port",
+  "bedeutung": "First home computer with a true 16-bit CPU. Innovative but expensive and with little software. Known for speech synthesis and solid educational software."
+};
+
+const translations_tisr56 = {
+  "hersteller": "Texas Instruments",
+  "tech_0": "Programmable with up to 100 instructions",
+  "tech_1": "Alphanumeric LED display",
+  "tech_2": "Statistical functions, register operations",
+  "tech_3": "Power supply: 9V battery or adapter",
+  "bedeutung": "The TI SR-56 was one of the first affordable scientific calculators with programmable memory. It was particularly popular with engineers and students."
+};
+
+const translations_triumphator = {
+  "hersteller": "Triumphator",
+  "tech_0": "System: pinwheel, Odhner principle",
+  "tech_1": "Digits: 10\u00d78\u00d713 (input\u00d7turns\u00d7result)",
+  "tech_2": "Drive: hand crank",
+  "tech_3": "Material: iron",
+  "tech_4": "Dimensions: approx. 26\u00d713\u00d713.5 cm",
+  "bedeutung": "Mechanical calculator from East Germany. Reliable, robust, used in offices and engineering \u2013 built from 1956 to 1958."
+};
+
+const translations_zx81 = {
+  "hersteller": "Sinclair",
+  "tech_0": "CPU: Z80A @ 3.25 MHz",
+  "tech_1": "RAM: 1 KB (expandable to 56 KB)",
+  "tech_2": "ROM: 8 KB BASIC",
+  "tech_3": "Graphics: 64\u00d748, monochrome",
+  "tech_4": "Storage: audio cassette",
+  "bedeutung": "Ultra-cheap home computer for beginners. Known for its minimalist hardware but widespread use in education."
+};
+
+const translations_zxspectrum = {
+  "hersteller": "Sinclair",
+  "tech_0": "CPU: Z80A @ 3.5 MHz",
+  "tech_1": "RAM: 16\u201348 KB",
+  "tech_2": "Graphics: 256\u00d7192, 15 colors",
+  "tech_3": "Sound: 1-channel buzzer",
+  "tech_4": "Storage: cassette",
+  "bedeutung": "One of Europe's most important home computers. Basis for thousands of games, origin of the British games industry."
+};


### PR DESCRIPTION
## Summary
- add translation objects for all device pages
- include language selector and translation script across device pages
- support translations by extending `pageTranslations`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d36973c888325be6fd1626f52ca38